### PR TITLE
fix: Improve annotations of PromiseInterface for psalm

### DIFF
--- a/src/PromiseInterface.php
+++ b/src/PromiseInterface.php
@@ -8,6 +8,7 @@ namespace React\Promise;
  * @note This is a stub interface for better IDE support.
  *
  * @yield T
+ * @psalm-yield T
  * @template-covariant T
  */
 interface PromiseInterface


### PR DESCRIPTION
<!-- Thanks for opening a PR! -->

## What was changed

The list of annotations for `PromiseInterface` has been expanded for a better understanding of psalm.

## Why?

The annotations specified in `PromiseInterface` do not work correctly for psalm:  
https://psalm.dev/r/491dc2f14a

If you add the `@psalm-yield` annotation, which is supported by psalm, the problem disappears:  
https://psalm.dev/r/5048107af6

## Checklist

- Tested
  - [x] Tested manually
  - [ ] Unit tests added
